### PR TITLE
PRISONER v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 The Facebook Gateway now targets version 2.4 of the Graph API and future
 experiments should request at least this in the "api_version" prop.
 
+* Docker demo template had a syntax error in its conditionals.
+
 ## PRISONER Version 1.1.0 (June 20, 2016)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## PRISONER Version 1.1.1 (September 13, 2016)
+
+### Bug fixes
+
+* Deprecated Facebook permission read_stream has been replaced with user_posts.
+The Facebook Gateway now targets version 2.4 of the Graph API and future
+experiments should request at least this in the "api_version" prop.
+
 ## PRISONER Version 1.1.0 (June 20, 2016)
 
 ### New features

--- a/examples/dockerdemo/static/out.html
+++ b/examples/dockerdemo/static/out.html
@@ -31,7 +31,7 @@
 		<p>This experiment displays the last ten
 		{% if provider == "Facebook" %}
 			status updates
-		{% elseif provider == "Twitter" %}
+		{% elif provider == "Twitter" %}
 			tweets
 		{% endif %}
 		from your profile
@@ -57,7 +57,7 @@
 		<div class="status">
 			{% if provider == "Facebook" %}
 			<span class="status_content"><a href="https://www.facebook.com/{{ post._id}}" target="_blank">
-			{% elseif provider == "Twitter" %}
+			{% elif provider == "Twitter" %}
 			<span class="status_content"><a href="https://www.twitter.com/{
 			{me._displayName}}/statuses/{{post._id}}"target="_blank">
 			{% endif %}

--- a/prisoner/gateway/FacebookGateway.py
+++ b/prisoner/gateway/FacebookGateway.py
@@ -63,7 +63,7 @@ class FacebookServiceGateway(ServiceGateway):
 			"Like": ["user_likes"],
 			"Movie": ["user_likes"],
 			"Book": ["user_likes"],
-			"Note": ["user_status", "user_posts", "read_stream", "publish_actions"],
+			"Note": ["user_status", "user_posts", "publish_actions"],
 			"Friends": ["user_friends"],
 			"Album": ["user_photos"],
 			"Image": ["user_photos"],


### PR DESCRIPTION
## PRISONER Version 1.1.1 (September 13, 2016)

### Bug fixes

* Deprecated Facebook permission read_stream has been replaced with user_posts.
The Facebook Gateway now targets version 2.4 of the Graph API and future
experiments should request at least this in the "api_version" prop.

* Docker demo template had a syntax error in its conditionals.